### PR TITLE
Fix typescript issue with typings (adapter-graphql)

### DIFF
--- a/packages/adapter-graphql/package.json
+++ b/packages/adapter-graphql/package.json
@@ -17,7 +17,7 @@
   "exports": {
     ".": {
       "types": {
-        "import": "./index.d.ts"
+        "import": "./dist/index.d.ts"
       },
       "browser": {
         "require": "./dist/browser/index.cjs.js",


### PR DESCRIPTION
We have an issue when trying to use the `adapter-graphql`.

TypeScript can't find the type definition file as the path is not properly set in `package.json`. This issue aims to fix this bug.

It seems to be a typo as the `core` package has its `exports.types.import` properly set.